### PR TITLE
add run with docker example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 # Rust
 target/*
 Cargo.lock
+
+# cargo
+.cargo/

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ lint:
 	cargo +nightly clippy -- -D warnings
 
 docker:
-	docker build -f docker/Dockerfile .
+	docker build --network host -f docker/Dockerfile -t datafusedev/fuse-query .
 
 clean:
 	cargo clean

--- a/README.md
+++ b/README.md
@@ -85,7 +85,20 @@ $ make run
 12:46:15 [ INFO] Usage: mysql -h127.0.0.1 -P3307
 ```
 
+or run with docker:
+
+```
+$ docker pull datafusedev/fuse-query
+...
+
+$ docker run --rm -p 3307:3307 docker.io/datafusedev/fuse-query
+05:12:36 [ INFO] Options { log_level: "debug", num_cpus: 6, mysql_handler_port: 3307 }
+05:12:36 [ INFO] Fuse-Query Cloud Compute Starts...
+05:12:36 [ INFO] Usage: mysql -h127.0.0.1 -P3307
+```
+
 #### Query with MySQL client
+
 ###### Connect
 
 ```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,9 @@
 FROM rust:1.48.0-buster AS builder
-
-RUN cargo install cargo-build-deps
 RUN rustup toolchain install nightly
-
-WORKDIR /app
-COPY Makefile /app
-COPY Cargo.toml /app
-RUN cargo fetch
-
-COPY src/ /app/src
+COPY ./ /app
 WORKDIR /app
 RUN make build
+
+FROM debian:buster
+COPY --from=builder /app/target/release/fuse-query /fuse-query
+ENTRYPOINT ["/fuse-query"]


### PR DESCRIPTION
eg:

```bash
$ docker run --rm  datafusedev/fuse-query
05:40:10 [ INFO] Options { log_level: "debug", num_cpus: 40, mysql_handler_port: 3307 }
05:40:10 [ INFO] Fuse-Query Cloud Compute Starts...
05:40:10 [ INFO] Usage: mysql -h127.0.0.1 -P3307
```

docker hub URL: https://hub.docker.com/r/datafusedev/fuse-query