### PR TITLE
Improve numbers_mt generate source performance 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ name = "fuse-query"
 path = "src/bin/fuse-query.rs"
 
 [dependencies]
-arrow = { git= "https://github.com/apache/arrow"}
+arrow = { git = "https://github.com/apache/arrow", rev = "0c419fc"}
 async-trait = "0.1"
 bincode = "1.3.1"
 futures = "0.3"

--- a/benches/bench_main.rs
+++ b/benches/bench_main.rs
@@ -8,4 +8,5 @@ mod benchmarks;
 
 criterion_main! {
     benchmarks::bench_pipeline::benches,
+    benchmarks::bench_aggregate::benches,
 }

--- a/benches/benchmarks/bench_aggregate.rs
+++ b/benches/benchmarks/bench_aggregate.rs
@@ -7,17 +7,14 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use fuse_query::datavalues::*;
 use std::sync::Arc;
 
-
 macro_rules! bench_suit {
-    ($C: expr, $OP: expr, $ARR: expr) => {
-        {
-            $C.bench_function(format!("{}", $OP).as_str(), |b| {
-                b.iter(|| {
-                    let _ = data_array_aggregate_op($OP, $ARR.clone()) ;
-                })
-            });
-        };
-    }
+    ($C: expr, $OP: expr, $ARR: expr) => {{
+        $C.bench_function(format!("{}", $OP).as_str(), |b| {
+            b.iter(|| {
+                let _ = data_array_aggregate_op($OP, $ARR.clone());
+            })
+        });
+    };};
 }
 
 fn criterion_benchmark_aggregate(c: &mut Criterion) {

--- a/benches/benchmarks/bench_aggregate.rs
+++ b/benches/benchmarks/bench_aggregate.rs
@@ -1,0 +1,34 @@
+// Copyright 2020 The VectorQuery Authors.
+//
+// Code is licensed under AGPL License, Version 3.0.
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use fuse_query::datavalues::*;
+use std::sync::Arc;
+
+
+macro_rules! bench_suit {
+    ($C: expr, $OP: expr, $ARR: expr) => {
+        {
+            $C.bench_function(format!("{}", $OP).as_str(), |b| {
+                b.iter(|| {
+                    let _ = data_array_aggregate_op($OP, $ARR.clone()) ;
+                })
+            });
+        };
+    }
+}
+
+fn criterion_benchmark_aggregate(c: &mut Criterion) {
+    let data: Vec<u64> = (0..1000000).collect();
+    let arr = Arc::new(UInt64Array::from(data));
+    let _ = bench_suit!(c, DataValueAggregateOperator::Count, arr.clone());
+    let _ = bench_suit!(c, DataValueAggregateOperator::Max, arr.clone());
+    let _ = bench_suit!(c, DataValueAggregateOperator::Min, arr.clone());
+    let _ = bench_suit!(c, DataValueAggregateOperator::Avg, arr.clone());
+    let _ = bench_suit!(c, DataValueAggregateOperator::Sum, arr.clone());
+}
+
+criterion_group!(benches, criterion_benchmark_aggregate,);
+criterion_main!(benches);

--- a/benches/benchmarks/mod.rs
+++ b/benches/benchmarks/mod.rs
@@ -2,5 +2,5 @@
 //
 // Code is licensed under AGPL License, Version 3.0.
 
-pub mod bench_pipeline;
 pub mod bench_aggregate;
+pub mod bench_pipeline;

--- a/benches/benchmarks/mod.rs
+++ b/benches/benchmarks/mod.rs
@@ -3,3 +3,4 @@
 // Code is licensed under AGPL License, Version 3.0.
 
 pub mod bench_pipeline;
+pub mod bench_aggregate;

--- a/docs/sqlstatement/select.md
+++ b/docs/sqlstatement/select.md
@@ -53,7 +53,7 @@ mysql> SELECT * FROM system.settings;
 +----------------+---------+
 | default_db     | default |
 | max_threads    | 8       |
-| max_block_size | 10000   |
+| max_block_size | 65536    |
 +----------------+---------+
 3 rows in set (0.00 sec)
 ```

--- a/docs/sqlstatement/set.md
+++ b/docs/sqlstatement/set.md
@@ -7,7 +7,7 @@ title: SET
 SET param = value
 ```
 
-Assigns value to the param setting for the current session. 
+Assigns value to the param setting for the current session.
 
 ## SETTINGS
 
@@ -18,7 +18,7 @@ mysql> SELECT * FROM system.settings;
 | name           | value   |
 +----------------+---------+
 | max_threads    | 8       |
-| max_block_size | 10000   |
+| max_block_size | 65536    |
 | default_db     | default |
 +----------------+---------+
 3 rows in set (0.00 sec)

--- a/docs/system/system-tables.md
+++ b/docs/system/system-tables.md
@@ -39,7 +39,7 @@ mysql> SELECT * FROM system.settings;
 +----------------+---------+---------------------------------------------------------------------------------------------------+
 | name           | value   | description                                                                                       |
 +----------------+---------+---------------------------------------------------------------------------------------------------+
-| max_block_size | 10000   | Maximum block size for reading                                                                    |
+| max_block_size | 65536    | Maximum block size for reading                                                                    |
 | max_threads    | 8       | The maximum number of threads to execute the request. By default, it is determined automatically. |
 | default_db     | default | The default database for current session                                                          |
 +----------------+---------+---------------------------------------------------------------------------------------------------+

--- a/src/contexts/context.rs
+++ b/src/contexts/context.rs
@@ -21,7 +21,7 @@ impl FuseQueryContext {
     pub fn try_create_ctx(datasource: Arc<Mutex<dyn IDataSource>>) -> FuseQueryResult<Arc<Self>> {
         let settings = SettingMap::create();
         settings.try_set_u64("max_threads", 8, "The maximum number of threads to execute the request. By default, it is determined automatically.")?;
-        settings.try_set_u64("max_block_size", 10000, "Maximum block size for reading")?;
+        settings.try_set_u64("max_block_size", 65536, "Maximum block size for reading")?;
         settings.try_set_string(
             "default_db",
             "default".to_string(),

--- a/src/contexts/options.rs
+++ b/src/contexts/options.rs
@@ -15,6 +15,7 @@ impl Options {
         let settings = SettingMap::create();
         settings.try_set_string("log_level", "debug".to_string(), "Log level")?;
         settings.try_set_u64("num_cpus", num_cpus::get() as u64, "The numbers of the pc")?;
+        settings.try_set_string("mysql_listen_host", "127.0.0.1".to_string(), "MySQL server bind host")?;
         settings.try_set_u64("mysql_handler_port", 3307, "MySQL protocol port")?;
         settings.try_set_u64(
             "mysql_handler_thread_num",
@@ -32,6 +33,11 @@ impl Options {
     pub fn get_num_cpus(&self) -> FuseQueryResult<u64> {
         let key = "num_cpus";
         self.settings.try_get_u64(key)
+    }
+
+    pub fn get_mysql_listen_host(&self) -> FuseQueryResult<String> {
+        let key = "mysql_listen_host";
+        self.settings.try_get_string(key)
     }
 
     pub fn get_mysql_handler_port(&self) -> FuseQueryResult<u64> {

--- a/src/contexts/options.rs
+++ b/src/contexts/options.rs
@@ -15,7 +15,11 @@ impl Options {
         let settings = SettingMap::create();
         settings.try_set_string("log_level", "debug".to_string(), "Log level")?;
         settings.try_set_u64("num_cpus", num_cpus::get() as u64, "The numbers of the pc")?;
-        settings.try_set_string("mysql_listen_host", "127.0.0.1".to_string(), "MySQL server bind host")?;
+        settings.try_set_string(
+            "mysql_listen_host",
+            "127.0.0.1".to_string(),
+            "MySQL server bind host",
+        )?;
         settings.try_set_u64("mysql_handler_port", 3307, "MySQL protocol port")?;
         settings.try_set_u64(
             "mysql_handler_thread_num",

--- a/src/datasources/system/numbers_stream.rs
+++ b/src/datasources/system/numbers_stream.rs
@@ -2,7 +2,10 @@
 //
 // Code is licensed under AGPL License, Version 3.0.
 
-use std::{task::{Context, Poll}, usize};
+use std::{
+    task::{Context, Poll},
+    usize,
+};
 
 use futures::stream::Stream;
 
@@ -10,14 +13,14 @@ use crate::datablocks::DataBlock;
 use crate::datasources::Partitions;
 use crate::datavalues::{DataSchemaRef, UInt64Array};
 use crate::error::FuseQueryResult;
-use std::sync::Arc;
-use std::ptr::NonNull;
 use std::alloc::Layout;
 use std::mem;
+use std::ptr::NonNull;
+use std::sync::Arc;
 
-use arrow::datatypes::DataType;
 use arrow::array::ArrayData;
 use arrow::buffer::Buffer;
+use arrow::datatypes::DataType;
 
 #[derive(Debug, Clone)]
 struct BlockRange {
@@ -82,22 +85,27 @@ impl Stream for NumbersStream {
             self.block_index += 1;
 
             unsafe {
-                let layout = Layout::from_size_align_unchecked(length * mem::size_of::<u64>(), mem::size_of::<u64>());
+                let layout = Layout::from_size_align_unchecked(
+                    length * mem::size_of::<u64>(),
+                    mem::size_of::<u64>(),
+                );
                 let p = std::alloc::alloc(layout) as *mut u64;
-                for i in current.begin ..current.end {
-                    *p.offset((i-current.begin) as isize) = i;
+                for i in current.begin..current.end {
+                    *p.offset((i - current.begin) as isize) = i;
                 }
-                let buffer = Buffer::from_raw_parts(
-                    NonNull::new(p as *mut u8).unwrap(), length, length);
+                let buffer =
+                    Buffer::from_raw_parts(NonNull::new(p as *mut u8).unwrap(), length, length);
 
                 let arr_data = ArrayData::builder(DataType::UInt64)
-                .len(length)
-                .offset(0)
-                .add_buffer(buffer)
-                .build();
+                    .len(length)
+                    .offset(0)
+                    .add_buffer(buffer)
+                    .build();
 
-                let block =
-                    DataBlock::create(self.schema.clone(), vec![Arc::new(UInt64Array::from(arr_data))]);
+                let block = DataBlock::create(
+                    self.schema.clone(),
+                    vec![Arc::new(UInt64Array::from(arr_data))],
+                );
                 Some(Ok(block))
             }
         } else {

--- a/src/datasources/system/numbers_stream.rs
+++ b/src/datasources/system/numbers_stream.rs
@@ -2,7 +2,7 @@
 //
 // Code is licensed under AGPL License, Version 3.0.
 
-use std::task::{Context, Poll};
+use std::{task::{Context, Poll}, usize};
 
 use futures::stream::Stream;
 
@@ -11,6 +11,13 @@ use crate::datasources::Partitions;
 use crate::datavalues::{DataSchemaRef, UInt64Array};
 use crate::error::FuseQueryResult;
 use std::sync::Arc;
+use std::ptr::NonNull;
+use std::alloc::Layout;
+use std::mem;
+
+use arrow::datatypes::DataType;
+use arrow::array::ArrayData;
+use arrow::buffer::Buffer;
 
 #[derive(Debug, Clone)]
 struct BlockRange {
@@ -71,12 +78,28 @@ impl Stream for NumbersStream {
     ) -> Poll<Option<Self::Item>> {
         Poll::Ready(if (self.block_index as usize) < self.blocks.len() {
             let current = self.blocks[self.block_index].clone();
+            let length = (current.end - current.begin) as usize;
             self.block_index += 1;
 
-            let data: Vec<u64> = (current.begin..current.end).collect();
-            let block =
-                DataBlock::create(self.schema.clone(), vec![Arc::new(UInt64Array::from(data))]);
-            Some(Ok(block))
+            unsafe {
+                let layout = Layout::from_size_align_unchecked(length * mem::size_of::<u64>(), mem::size_of::<u64>());
+                let p = std::alloc::alloc(layout) as *mut u64;
+                for i in current.begin ..current.end {
+                    *p.offset((i-current.begin) as isize) = i;
+                }
+                let buffer = Buffer::from_raw_parts(
+                    NonNull::new(p as *mut u8).unwrap(), length, length);
+
+                let arr_data = ArrayData::builder(DataType::UInt64)
+                .len(length)
+                .offset(0)
+                .add_buffer(buffer)
+                .build();
+
+                let block =
+                    DataBlock::create(self.schema.clone(), vec![Arc::new(UInt64Array::from(arr_data))]);
+                Some(Ok(block))
+            }
         } else {
             None
         })

--- a/src/executors/executor_setting.rs
+++ b/src/executors/executor_setting.rs
@@ -44,6 +44,9 @@ impl IExecutor for SettingExecutor {
                 let value = plan.value.parse::<u64>()?;
                 self.ctx.set_max_threads(value)?;
             }
+            // To be ompatiable with some drivers
+            // eg: usql and mycli
+            "sql_mode" | "autocommit" => {}
             _ => {
                 return Err(FuseQueryError::Internal(format!(
                     "Unknown variable: {:?}",

--- a/src/servers/mysql/mysql_handler.rs
+++ b/src/servers/mysql/mysql_handler.rs
@@ -133,7 +133,7 @@ impl MySQLHandler {
 
     pub fn start(&self) -> FuseQueryResult<()> {
         let listener =
-            net::TcpListener::bind(format!("0.0.0.0:{}", self.opts.get_mysql_handler_port()?))?;
+            net::TcpListener::bind(format!("{}:{}", self.opts.get_mysql_listen_host()?, self.opts.get_mysql_handler_port()?))?;
         let pool = ThreadPool::new(self.opts.get_mysql_handler_thread_num()? as usize);
 
         for stream in listener.incoming() {

--- a/src/servers/mysql/mysql_handler.rs
+++ b/src/servers/mysql/mysql_handler.rs
@@ -132,8 +132,11 @@ impl MySQLHandler {
     }
 
     pub fn start(&self) -> FuseQueryResult<()> {
-        let listener =
-            net::TcpListener::bind(format!("{}:{}", self.opts.get_mysql_listen_host()?, self.opts.get_mysql_handler_port()?))?;
+        let listener = net::TcpListener::bind(format!(
+            "{}:{}",
+            self.opts.get_mysql_listen_host()?,
+            self.opts.get_mysql_handler_port()?
+        ))?;
         let pool = ThreadPool::new(self.opts.get_mysql_handler_thread_num()? as usize);
 
         for stream in listener.incoming() {


### PR DESCRIPTION

## Changes:

1. Improve numbers_mt generate source performance (About 2x improvement).
2. Introduce settings `mysql_listen_host`, defaults to `12.0.0.1` for security reason.
3. Set `max_block_size` to `65536` for better performance.

## Performance comparison 

- fuse-query


```
mysql> SELECT count(number) FROM system.numbers_mt(10000000000);
+---------------+
| count(number) |
+---------------+
|   10000000000 |
+---------------+
1 row in set (0.28 sec)

mysql> SELECT max(number) FROM system.numbers_mt(10000000000);
+-------------+
| max(number) |
+-------------+
|  9999999999 |
+-------------+
1 row in set (0.45 sec)

mysql> SELECT avg(number) FROM system.numbers_mt(10000000000);
+--------------+
| avg(number)  |
+--------------+
| 4999999999.5 |
+--------------+
1 row in set (0.50 sec)
```


- ClickHouse 

```
:)  SELECT count(number) FROM  numbers_mt(10000000000)

SELECT count(number)
FROM numbers_mt(10000000000)


1 rows in set. Elapsed: 0.520 sec. Processed 10.00 billion rows, 80.00 GB (19.24 billion rows/s., 153.94 GB/s.)

:) SELECT max(number) FROM  numbers_mt(10000000000);

SELECT max(number)
FROM numbers_mt(10000000000)


1 rows in set. Elapsed: 1.525 sec. Processed 10.00 billion rows, 80.00 GB (6.56 billion rows/s., 52.46 GB/s.)

:) SELECT avg(number) FROM  numbers_mt(10000000000);

SELECT avg(number)
FROM numbers_mt(10000000000)


1 rows in set. Elapsed: 1.167 sec. Processed 10.00 billion rows, 80.00 GB (8.57 billion rows/s., 68.56 GB/s.)

```
