### PR TITLE
[system-tables] Add system.one table

### DIFF
--- a/src/datasources/datasource.rs
+++ b/src/datasources/datasource.rs
@@ -34,6 +34,7 @@ impl DataSource {
         )?;
         datasource.add_table("system", Arc::new(system::FunctionsTable::create()))?;
         datasource.add_table("system", Arc::new(system::SettingsTable::create()))?;
+        datasource.add_table("system", Arc::new(system::OneTable::create()))?;
 
         Ok(datasource)
     }

--- a/src/datasources/system/mod.rs
+++ b/src/datasources/system/mod.rs
@@ -8,9 +8,11 @@ mod settings_table_test;
 mod functions_table;
 mod numbers_stream;
 mod numbers_table;
+mod one_table;
 mod settings_table;
 
 pub use self::functions_table::FunctionsTable;
 pub use self::numbers_stream::NumbersStream;
 pub use self::numbers_table::NumbersTable;
+pub use self::one_table::OneTable;
 pub use self::settings_table::SettingsTable;

--- a/src/datasources/system/one_table.rs
+++ b/src/datasources/system/one_table.rs
@@ -1,0 +1,75 @@
+// Copyright 2020 The FuseQuery Authors.
+//
+// Code is licensed under AGPL License, Version 3.0.
+
+use async_trait::async_trait;
+use std::sync::Arc;
+
+use crate::contexts::FuseQueryContextRef;
+use crate::datablocks::DataBlock;
+use crate::datasources::{ITable, Partition, Statistics};
+use crate::datastreams::{DataBlockStream, SendableDataBlockStream};
+use crate::datavalues::{DataField, DataSchema, DataSchemaRef, DataType, UInt8Array};
+use crate::error::FuseQueryResult;
+use crate::planners::{PlanNode, ReadDataSourcePlan};
+
+pub struct OneTable {
+    schema: DataSchemaRef,
+}
+
+impl OneTable {
+    pub fn create() -> Self {
+        OneTable {
+            schema: Arc::new(DataSchema::new(vec![DataField::new(
+                "dummy",
+                DataType::UInt8,
+                false,
+            )])),
+        }
+    }
+}
+
+#[async_trait]
+impl ITable for OneTable {
+    fn name(&self) -> &str {
+        "one"
+    }
+
+    fn schema(&self) -> FuseQueryResult<DataSchemaRef> {
+        Ok(self.schema.clone())
+    }
+
+    fn read_plan(
+        &self,
+        _ctx: FuseQueryContextRef,
+        _push_down_plan: PlanNode,
+    ) -> FuseQueryResult<ReadDataSourcePlan> {
+        Ok(ReadDataSourcePlan {
+            db: "system".to_string(),
+            table: self.name().to_string(),
+            schema: self.schema.clone(),
+            partitions: vec![Partition {
+                name: "".to_string(),
+                version: 0,
+            }],
+            statistics: Statistics::default(),
+            description: "(Read from system.one table)".to_string(),
+        })
+    }
+
+    async fn read(
+        &self,
+        _: FuseQueryContextRef,
+        _parts: Vec<Partition>,
+    ) -> FuseQueryResult<SendableDataBlockStream> {
+        let block = DataBlock::create(
+            self.schema.clone(),
+            vec![Arc::new(UInt8Array::from(vec![1u8]))],
+        );
+        Ok(Box::pin(DataBlockStream::create(
+            self.schema.clone(),
+            None,
+            vec![block],
+        )))
+    }
+}

--- a/src/datavalues/data_type.rs
+++ b/src/datavalues/data_type.rs
@@ -24,6 +24,7 @@ fn is_numeric(dt: &DataType) -> bool {
     )
 }
 
+// TODO: modify this, because this function is not right, eg: UInt8 * UInt8 should be UInt16
 pub fn numerical_coercion(
     op: &str,
     lhs_type: &DataType,

--- a/src/executors/executor_select_test.rs
+++ b/src/executors/executor_select_test.rs
@@ -7,6 +7,7 @@ async fn test_select_executor() -> crate::error::FuseQueryResult<()> {
     use futures::stream::StreamExt;
 
     use crate::contexts::*;
+    use crate::datavalues::*;
     use crate::executors::*;
     use crate::planners::*;
     use crate::tests;
@@ -18,13 +19,40 @@ async fn test_select_executor() -> crate::error::FuseQueryResult<()> {
         ctx.clone(),
         "select number from system.numbers_mt(10) where (number+2)<2",
     )? {
-        let executor = SelectExecutor::try_create(ctx, plan)?;
+        let executor = SelectExecutor::try_create(ctx.clone(), plan)?;
         assert_eq!(executor.name(), "SelectExecutor");
 
         let mut stream = executor.execute().await?;
         while let Some(_block) = stream.next().await {}
     } else {
         assert!(false)
+    }
+
+    if let PlanNode::Select(plan) =
+        Planner::new().build_from_sql(ctx.clone(), "select 1 + 1, 2 + 2, 3 * 3, 4 * 4")?
+    {
+        let executor = SelectExecutor::try_create(ctx.clone(), plan)?;
+        assert_eq!(executor.name(), "SelectExecutor");
+
+        let mut stream = executor.execute().await?;
+        if let Some(block) = stream.next().await {
+            let record_batch = block?.to_arrow_batch()?;
+            assert_eq!(1, record_batch.num_rows());
+            assert_eq!(4, record_batch.num_columns());
+
+            let sc = record_batch.schema().clone();
+            let types: Vec<&DataType> = sc.fields().iter().map(|f| f.data_type()).collect();
+            assert_eq!(
+                vec![
+                    &DataType::UInt64,
+                    &DataType::UInt64,
+                    &DataType::UInt64,
+                    &DataType::UInt64
+                ],
+                types
+            );
+        }
+        while let Some(_block) = stream.next().await {}
     }
 
     Ok(())

--- a/src/executors/executor_setting.rs
+++ b/src/executors/executor_setting.rs
@@ -36,7 +36,7 @@ impl IExecutor for SettingExecutor {
     async fn execute(&self) -> FuseQueryResult<SendableDataBlockStream> {
         let plan = self.set.clone();
         match plan.variable.to_lowercase().as_str() {
-            // To be ompatiable with some drivers
+            // To be compatible with some drivers
             // eg: usql and mycli
             "sql_mode" | "autocommit" => {}
             _ => {


### PR DESCRIPTION
- Add `system.one` table for dummy source.
- Queries without tables in from will add planer to read from this table, eg `select 1 + 1`